### PR TITLE
Updates include change to wildfly plugin, use jboss prefix with quick…

### DIFF
--- a/jaxws-addressing/README.md
+++ b/jaxws-addressing/README.md
@@ -1,11 +1,10 @@
 jaxws-addressing: A WS-addressing JAX-WS Web Service
 ==================================================
-Author: R Searls
+Author: R Searls  
 Level: Beginner  
 Technologies: JAX-WS  
-Summary: The `jaxws-addressing` quickstart is a working example of the web service using WS-Addressing.
-Target Product: EAP  
-Product Versions: EAP 6.1, EAP 6.2, EAP 6.3, EAP 6.4  
+Summary: The `jaxws-addressing` quickstart is a working example of the web service using WS-Addressing.  
+Target Product: JBoss EAP  
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>  
 
 What is it?
@@ -46,22 +45,27 @@ _NOTE: The following build command assumes you have configured your Maven user s
 2. Open a command prompt and navigate to the root directory of this quickstart.
 3. Type this command to build and deploy the archive:
 
-        mvn clean install jboss-as:deploy
+        mvn clean install wildfy:deploy
 
-4. This will deploy `service/target/jboss-jaxws-addressing-service.war` to the running instance of the server.
+4. This will create the `jboss-jaxws-addressing-client.jar` and deploy `service/target/jboss-jaxws-addressing-service.war` to the running instance of the server.
 
 Access the application 
 ---------------------
 
-You can check that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/jaxws-samples-wsa/AddressingService?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
+You can check that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/jboss-jaxws-addressing/AddressingService?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
 
 Run the Client
 --------------
 1. Make sure the service deployed properly.
 2. Open a command prompt and navigate into the client directory of this quickstart.
+
+        cd client/
 3. Type this command to run the client.
 
-     mvn exec:java
+        mvn exec:java
+4. You should see the following output in the client console.
+   
+        Hello World!
 
 Undeploy the Archive
 --------------------
@@ -70,4 +74,4 @@ Undeploy the Archive
 2. Open a command prompt and navigate to the root directory of this quickstart.
 3. When you are finished testing, type this command to undeploy the archive:
 
-        mvn jboss-as:undeploy
+        mvn wildfy:undeploy

--- a/jaxws-addressing/client/pom.xml
+++ b/jaxws-addressing/client/pom.xml
@@ -24,7 +24,7 @@
    <parent>
       <groupId>org.jboss.quickstarts.eap</groupId>
       <artifactId>jboss-jaxws-addressing</artifactId>
-      <version>6.4.0-redhat-SNAPSHOT</version>
+      <version>7.0.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>jboss-jaxws-addressing-client</artifactId>

--- a/jaxws-addressing/client/src/main/java/org/jboss/quickstarts/ws/jaxws/samples/wsa/AddressingTestCase.java
+++ b/jaxws-addressing/client/src/main/java/org/jboss/quickstarts/ws/jaxws/samples/wsa/AddressingTestCase.java
@@ -28,7 +28,7 @@ import javax.xml.ws.soap.AddressingFeature;
 public final class AddressingTestCase
 {
     private static final String serviceURL =
-        "http://localhost:8080/jaxws-samples-wsa/AddressingService";
+        "http://localhost:8080/jboss-jaxws-addressing/AddressingService";
 
     public static void main(String[] args) throws Exception
     {

--- a/jaxws-addressing/pom.xml
+++ b/jaxws-addressing/pom.xml
@@ -21,7 +21,7 @@
 
    <groupId>org.jboss.quickstarts.eap</groupId>
    <artifactId>jboss-jaxws-addressing</artifactId>
-   <version>6.4.0-redhat-SNAPSHOT</version>
+   <version>7.0.0-SNAPSHOT</version>
    <packaging>pom</packaging>
 
    <name>EAP Quickstart: jaxws-addressing</name>
@@ -99,7 +99,7 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <!-- JBoss dependency versions -->
-      <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
+      <version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
       <!-- maven-compiler-plugin -->
       <maven.compiler.target>1.8</maven.compiler.target>
       <maven.compiler.source>1.8</maven.compiler.source>
@@ -138,9 +138,9 @@
    <build>
       <plugins>
          <plugin>
-            <groupId>org.jboss.as.plugins</groupId>
-            <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${version.jboss.maven.plugin}</version>
+            <groupId>org.wildfly.plugins</groupId>
+            <artifactId>wildfly-maven-plugin</artifactId>
+            <version>${version.wildfly.maven.plugin}</version>
             <configuration>
                <skip>true</skip>
             </configuration>

--- a/jaxws-addressing/service/pom.xml
+++ b/jaxws-addressing/service/pom.xml
@@ -23,7 +23,7 @@
    <parent>
       <groupId>org.jboss.quickstarts.eap</groupId>
       <artifactId>jboss-jaxws-addressing</artifactId>
-      <version>6.4.0-redhat-SNAPSHOT</version>
+      <version>7.0.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>jboss-jaxws-addressing-service</artifactId>
@@ -53,11 +53,14 @@
                     <attachClasses>true</attachClasses>
                 </configuration>
             </plugin>
-            <!-- JBoss AS plugin to deploy war -->
+            <!-- Wildfly plugin to deploy war -->
             <plugin>
-                <groupId>org.jboss.as.plugins</groupId>
-                <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${version.jboss.maven.plugin}</version>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.wildfly.maven.plugin}</version>
+                <configuration>
+                   <skip>false</skip>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/jaxws-addressing/service/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/jaxws-addressing/service/src/main/webapp/WEB-INF/jboss-web.xml
@@ -15,6 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
+<!DOCTYPE jboss-web>
 <jboss-web>
-    <context-root>jaxws-samples-wsa</context-root>
+    <context-root>jboss-jaxws-addressing</context-root>
 </jboss-web>

--- a/jaxws-ejb/README.md
+++ b/jaxws-ejb/README.md
@@ -1,11 +1,10 @@
 jaxws-ejb: An EJB JAX-WS Web Service
 ==================================================
-Author: R Searls
+Author: R Searls  
 Level: Beginner  
 Technologies: JAX-WS  
-Summary: The `jaxws-ejb` quickstart is a working example of the web service endpoint created from an EJB.
-Target Product: EAP  
-Product Versions: EAP 6.1, EAP 6.2, EAP 6.3, EAP 6.4  
+Summary: The `jaxws-ejb` quickstart is a working example of the web service endpoint created from an EJB.  
+Target Product: JBoss EAP  
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>  
 
 What is it?
@@ -46,22 +45,27 @@ _NOTE: The following build command assumes you have configured your Maven user s
 2. Open a command prompt and navigate to the root directory of this quickstart.
 3. Type this command to build and deploy the archive:
 
-        mvn clean install jboss-as:deploy
+        mvn clean install wildfy:deploy
 
 4. This will deploy `service/target/jboss-jaxws-ejb-service.war` to the running instance of the server.
 
 Access the application 
 ---------------------
 
-You can check that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/jaxws-samples-endpoint-ejb/EJB3Bean01?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
+You can check that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/jboss-jaxws-ejb-endpoint/EJB3Bean01?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
 
 Run the Client
 --------------
 1. Make sure the service deployed properly.
 2. Open a command prompt and navigate into the client directory of this quickstart.
+
+        cd client/
 3. Type this command to run the client.
      
-     mvn exec:java    
+        mvn exec:java    
+4. You should see the following output in the client console.
+   
+        EJB3Bean01 returning: ejbClient calling
 
 Undeploy the Archive
 --------------------
@@ -70,4 +74,4 @@ Undeploy the Archive
 2. Open a command prompt and navigate to the root directory of this quickstart.
 3. When you are finished testing, type this command to undeploy the archive:
 
-        mvn jboss-as:undeploy
+        mvn wildfy:undeploy

--- a/jaxws-ejb/client/pom.xml
+++ b/jaxws-ejb/client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.quickstarts.eap</groupId>
         <artifactId>jboss-jaxws-ejb</artifactId>
-        <version>6.4.0-redhat-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jboss-jaxws-ejb-client</artifactId>
@@ -80,6 +80,7 @@
    </dependencies>
 
    <build>
+      <finalName>${project.artifactId}</finalName>
       <plugins>
          <!-- Allows Client to be run via 'mvn exec:java' -->
          <plugin>

--- a/jaxws-ejb/client/src/main/java/org/jboss/quickstarts/ws/client/Client.java
+++ b/jaxws-ejb/client/src/main/java/org/jboss/quickstarts/ws/client/Client.java
@@ -31,7 +31,7 @@ public class Client {
 
     public static void main (String [] args)
     {
-        String endPointAddress = "http://localhost:8080/jaxws-samples-endpoint-ejb/EJB3Bean01";
+        String endPointAddress = "http://localhost:8080/jboss-jaxws-ejb-endpoint/EJB3Bean01";
         QName serviceName = new QName("http://jsr181pojo.samples.jaxws.ws.quickstarts.jboss.org/", "EJB3Bean01Service");
 
         try {

--- a/jaxws-ejb/pom.xml
+++ b/jaxws-ejb/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>org.jboss.quickstarts.eap</groupId>
   <artifactId>jboss-jaxws-ejb</artifactId>
-  <version>6.4.0-redhat-SNAPSHOT</version>
+  <version>7.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
     <name>EAP Quickstart: jaxws-ejb</name>
@@ -98,20 +98,20 @@
         <!-- Explicitly declaring the source encoding eliminates the following message: -->
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
         <!-- JBoss dependency versions -->
-        <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
-        <!-- maven-compiler-plugin -->
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <version.exec.plugin>1.2.1</version.exec.plugin>
+        <version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
+
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <version.jboss.bom.eap>7.0.0-build-5</version.jboss.bom.eap>
-        <version.maven-jar-plugin>2.5</version.maven-jar-plugin>
-        <version.onejar-maven-plugin>1.4.4</version.onejar-maven-plugin>
         <version.war.plugin>2.1.1</version.war.plugin>
         <version.jboss-ejb3-ext-api>2.0.0-redhat-2</version.jboss-ejb3-ext-api>
         <version.istack.commons.runtime>2.6.1.redhat-3</version.istack.commons.runtime>
         <version.jboss-ejb-api_3.2_spec>1.0.0.Final</version.jboss-ejb-api_3.2_spec>           
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
     </properties>
 
     <modules>
@@ -171,9 +171,9 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.jboss.as.plugins</groupId>
-                <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${version.jboss.maven.plugin}</version>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.wildfly.maven.plugin}</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/jaxws-ejb/service/pom.xml
+++ b/jaxws-ejb/service/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.jboss.quickstarts.eap</groupId>
         <artifactId>jboss-jaxws-ejb</artifactId>
-        <version>6.4.0-redhat-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jboss-jaxws-ejb-service</artifactId>
@@ -71,11 +71,14 @@
                     <attachClasses>true</attachClasses>
                 </configuration>
             </plugin>
-            <!-- JBoss AS plugin to deploy war -->
+            <!-- Wildfly plugin to deploy war -->
             <plugin>
-                <groupId>org.jboss.as.plugins</groupId>
-                <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${version.jboss.maven.plugin}</version>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.wildfly.maven.plugin}</version>
+                <configuration>
+                   <skip>false</skip>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/jaxws-ejb/service/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/jaxws-ejb/service/src/main/webapp/WEB-INF/jboss-web.xml
@@ -16,5 +16,5 @@
     limitations under the License.
 -->
 <jboss-web>
-    <context-root>jaxws-samples-endpoint-ejb</context-root>
+    <context-root>jboss-jaxws-ejb-endpoint</context-root>
 </jboss-web>

--- a/jaxws-pojo/README.md
+++ b/jaxws-pojo/README.md
@@ -1,11 +1,10 @@
 jaxws-pojo: An POJO JAX-WS Web Service
 ==================================================
-Author: R Searls
+Author: R Searls  
 Level: Beginner  
 Technologies: JAX-WS  
 Summary: The `jaxws-pojo` quickstart is a working example of the web service endpoint created from a POJO.
-Target Product: EAP  
-Product Versions: EAP 6.1, EAP 6.2, EAP 6.3, EAP 6.4  
+Target Product: JBoss EAP  
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>  
 
 What is it?
@@ -46,14 +45,14 @@ _NOTE: The following build command assumes you have configured your Maven user s
 2. Open a command prompt and navigate to the root directory of this quickstart.
 3. Type this command to build and deploy the archive:
 
-        mvn clean install jboss-as:deploy
+        mvn clean install wildfy:deploy
 
 4. This will deploy `service/target/jboss-jaxws-pojo-service.war` to the running instance of the server.
 
 Access the application 
 ---------------------
 
-You can check that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/jaxws-samples-endpoint-pojo/JSEBean01?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
+You can check that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/jboss-jaxws-pojo-endpoint/JSEBean01?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
 
 Run the Client
 --------------
@@ -61,7 +60,11 @@ Run the Client
 2. Open a command prompt and navigate to the root directory of this quickstart.
 3. Type this command to run the client.
 
-     java -jar client/target/jboss-jaxws-pojo-client.jar   org.jboss.quickstarts.ws.client.Client
+        java -jar client/target/jboss-jaxws-pojo-client.jar   org.jboss.quickstarts.ws.client.Client
+4. You should see the following response.
+
+        JSEBean01 pojo: pojoClient calling
+
 
 Undeploy the Archive
 --------------------
@@ -70,4 +73,4 @@ Undeploy the Archive
 2. Open a command prompt and navigate to the root directory of this quickstart.
 3. When you are finished testing, type this command to undeploy the archive:
 
-        mvn jboss-as:undeploy
+        mvn wildfy:undeploy

--- a/jaxws-pojo/client/pom.xml
+++ b/jaxws-pojo/client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.quickstarts.eap</groupId>
         <artifactId>jboss-jaxws-pojo</artifactId>
-        <version>6.4.0-redhat-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jboss-jaxws-pojo-client</artifactId>

--- a/jaxws-pojo/client/src/main/java/org/jboss/quickstarts/ws/client/Client.java
+++ b/jaxws-pojo/client/src/main/java/org/jboss/quickstarts/ws/client/Client.java
@@ -30,7 +30,7 @@ public class Client {
 
     public static void main (String [] args)
     {
-        String endPointAddress = "http://localhost:8080/jaxws-samples-endpoint-pojo/JSEBean01";
+        String endPointAddress = "http://localhost:8080/jboss-jaxws-pojo-endpoint/JSEBean01";
         QName serviceName = new QName("http://jsr181pojo.samples.jaxws.ws.quickstarts.jboss.org/", "JSEBean01Service");
 
         try {

--- a/jaxws-pojo/pom.xml
+++ b/jaxws-pojo/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>org.jboss.quickstarts.eap</groupId>
   <artifactId>jboss-jaxws-pojo</artifactId>
-  <version>6.4.0-redhat-SNAPSHOT</version>
+  <version>7.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
     <name>EAP Quickstart: jaxws-pojo</name>
@@ -99,7 +99,7 @@
         <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- JBoss dependency versions -->
-        <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
+        <version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -141,9 +141,9 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.jboss.as.plugins</groupId>
-                <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${version.jboss.maven.plugin}</version>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.wildfly.maven.plugin}</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/jaxws-pojo/service/pom.xml
+++ b/jaxws-pojo/service/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.jboss.quickstarts.eap</groupId>
         <artifactId>jboss-jaxws-pojo</artifactId>
-        <version>6.4.0-redhat-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jboss-jaxws-pojo-service</artifactId>
@@ -53,11 +53,14 @@
                     <attachClasses>true</attachClasses>
                 </configuration>
             </plugin>
-            <!-- JBoss AS plugin to deploy war -->
+            <!-- Wildfly plugin to deploy war -->
             <plugin>
-                <groupId>org.jboss.as.plugins</groupId>
-                <artifactId>jboss-as-maven-plugin</artifactId>
-                <version>${version.jboss.maven.plugin}</version>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.wildfly.maven.plugin}</version>
+                <configuration>
+                   <skip>false</skip>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/jaxws-pojo/service/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/jaxws-pojo/service/src/main/webapp/WEB-INF/jboss-web.xml
@@ -16,5 +16,5 @@
     limitations under the License.
 -->
 <jboss-web>
-    <context-root>jaxws-samples-endpoint-pojo</context-root>
+    <context-root>jboss-jaxws-pojo-endpoint</context-root>
 </jboss-web>

--- a/jaxws-retail/README.md
+++ b/jaxws-retail/README.md
@@ -1,11 +1,10 @@
 jaxws-retail: A Retail JAX-WS Web Service
 =========================================
-Author: R Searls
+Author: R Searls  
 Level: Beginner  
 Technologies: JAX-WS  
 Summary: The `jaxws-retail` quickstart is a working example of a simple web service endpoint.
-Target Product: EAP  
-Product Versions: EAP 6.1, EAP 6.2, EAP 6.3, EAP 6.4  
+Target Product: JBoss EAP  
 Source: <https://github.com/jboss-developer/jboss-eap-quickstarts/>  
 
 What is it?
@@ -46,22 +45,29 @@ _NOTE: The following build command assumes you have configured your Maven user s
 2. Open a command prompt and navigate to the root directory of this quickstart.
 3. Type this command to build and deploy the archive:
 
-        mvn clean install jboss-as:deploy
+        mvn clean install wildfy:deploy
 
 4. This will deploy `service/target/jboss-jaxws-retail-service.war` to the running instance of the server.
 
 Access the application 
 ---------------------
 
-You can check that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/jaxws-samples-retail/ProfileMgmtService/ProfileMgmt?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
+You can check that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/jboss-jaxws-retail/ProfileMgmtService/ProfileMgmt?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
 
 Run the Client
 --------------
 1. Make sure the service deployed properly.
 2. Open a command prompt and navigate into the client directory of this quickstart.
+
+     cd client/
 3. Type this command to run the client.
 
      mvn exec:java
+     
+4. You should see the following output in the client console.
+   
+     Jay Boss's discount is 10.00
+
 
 Undeploy the Archive
 --------------------
@@ -70,4 +76,4 @@ Undeploy the Archive
 2. Open a command prompt and navigate to the root directory of this quickstart.
 3. When you are finished testing, type this command to undeploy the archive:
 
-        mvn jboss-as:undeploy
+        mvn wildfy:undeploy

--- a/jaxws-retail/client/pom.xml
+++ b/jaxws-retail/client/pom.xml
@@ -24,7 +24,7 @@
    <parent>
       <groupId>org.jboss.quickstarts.eap</groupId>
       <artifactId>jboss-jaxws-retail</artifactId>
-      <version>6.4.0-redhat-SNAPSHOT</version>
+      <version>7.0.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>jboss-jaxws-retail-client</artifactId>

--- a/jaxws-retail/client/src/main/java/org/jboss/quickstarts/ws/client/Client.java
+++ b/jaxws-retail/client/src/main/java/org/jboss/quickstarts/ws/client/Client.java
@@ -33,7 +33,7 @@ public class Client {
 
     public static void main (String [] args)
     {
-        String endPointAddress = "http://localhost:8080/jaxws-samples-retail/ProfileMgmtService/ProfileMgmt";
+        String endPointAddress = "http://localhost:8080/jboss-jaxws-retail/ProfileMgmtService/ProfileMgmt";
         QName serviceName = new QName("http://org.jboss.ws/samples/retail/profile", "ProfileMgmtService");
 
         try {

--- a/jaxws-retail/pom.xml
+++ b/jaxws-retail/pom.xml
@@ -22,7 +22,7 @@
 
    <groupId>org.jboss.quickstarts.eap</groupId>
    <artifactId>jboss-jaxws-retail</artifactId>
-   <version>6.4.0-redhat-SNAPSHOT</version>
+   <version>7.0.0-SNAPSHOT</version>
    <packaging>pom</packaging>
 
    <name>EAP Quickstart: jaxws-retail</name>
@@ -100,7 +100,7 @@
       <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent! -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <!-- JBoss dependency versions -->
-      <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
+      <version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
       <!-- maven-compiler-plugin -->
       <maven.compiler.target>1.8</maven.compiler.target>
       <maven.compiler.source>1.8</maven.compiler.source>
@@ -151,9 +151,9 @@
    <build>
       <plugins>
          <plugin>
-            <groupId>org.jboss.as.plugins</groupId>
-            <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${version.jboss.maven.plugin}</version>
+            <groupId>org.wildfly.plugins</groupId>
+            <artifactId>wildfly-maven-plugin</artifactId>
+            <version>${version.wildfly.maven.plugin}</version>
             <configuration>
                <skip>true</skip>
             </configuration>

--- a/jaxws-retail/service/pom.xml
+++ b/jaxws-retail/service/pom.xml
@@ -23,7 +23,7 @@
    <parent>
       <groupId>org.jboss.quickstarts.eap</groupId>
       <artifactId>jboss-jaxws-retail</artifactId>
-      <version>6.4.0-redhat-SNAPSHOT</version>
+      <version>7.0.0-SNAPSHOT</version>
       <!-- -->
       <relativePath>../pom.xml</relativePath>
       
@@ -68,11 +68,11 @@
                <attachClasses>true</attachClasses>
             </configuration>
          </plugin>
-         <!-- JBoss AS plugin to deploy war -->
+         <!-- Wildfly plugin to deploy war -->
          <plugin>
-            <groupId>org.jboss.as.plugins</groupId>
-            <artifactId>jboss-as-maven-plugin</artifactId>
-            <version>${version.jboss.maven.plugin}</version>
+            <groupId>org.wildfly.plugins</groupId>
+            <artifactId>wildfly-maven-plugin</artifactId>
+            <version>${version.wildfly.maven.plugin}</version>
             <configuration>
                <skip>false</skip>
             </configuration>

--- a/jaxws-retail/service/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/jaxws-retail/service/src/main/webapp/WEB-INF/jboss-web.xml
@@ -16,5 +16,5 @@
     limitations under the License.
 -->
 <jboss-web>
-   <context-root>jaxws-samples-retail</context-root>
+   <context-root>jboss-jaxws-retail</context-root>
 </jboss-web>

--- a/jaxws-retail/service/src/main/webapp/WEB-INF/wsdl/ProfileMgmtService.wsdl
+++ b/jaxws-retail/service/src/main/webapp/WEB-INF/wsdl/ProfileMgmtService.wsdl
@@ -81,7 +81,7 @@
       <port binding='tns:ProfileMgmtBinding' name='ProfileMgmtPort'>
  
          <soap:address
-             location='SERVER:PORT/jaxws-samples-retail/ProfileMgmtBean'/>
+             location='SERVER:PORT/jboss-jaxws-retail/ProfileMgmtBean'/>
       </port>
    </service>
 </definitions>	


### PR DESCRIPTION
Hi Rebecca,
I had to make a number of changes to these quickstarts. Could you please review and merge them with yours if you approve?

Changes were to fix the following things:
- Use the wildfly plugin
- Build projects using the project artifact id variable, which is jboss-<quickstart-folder-name>
- Deployed context root must also use the project  artifact id to prevent stepping on anything else they may have deployed. So it looks like http://localhost:8080/jboss-jaxws-addressing/...
- Metadata in the README needs 2 spaces at the end. Plus, we changed the Target Product and removed the Product Version.
- Fixed artifact version for 7.0.0-SNAPSHOT
- Assorted other fixes.
